### PR TITLE
Reduce crate size considerably with an include directive in manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 documentation = "https://docs.rs/bevy_skybox/"
 repository = "https://github.com/jomala/bevy_skybox/"
 edition = "2018"
+include = ["src/**/*", "README.md", "CHANGELOG.md"]
 
 [dependencies]
 bevy = "0.4"


### PR DESCRIPTION
Please let me know if there are other files you would like to have
included and I can adjust the manifest accordingly.

Here is the output of `cargo diet`:

```
➜  bevy_skybox git:(master) cargo diet
┌───────────────────────────────┬─────────────┐
│ Removed File                  │ Size (Byte) │
├───────────────────────────────┼─────────────┤
│ .gitignore                    │          28 │
│ examples/basic.rs             │         342 │
│ docs/measuring_the_net.drawio │        2130 │
│ examples/board_flyover.rs     │        3315 │
│ docs/measuring_the_net.png    │       18423 │
│ docs/board_flyover.png        │      204541 │
│ assets/sky2.png               │     1892243 │
│ assets/sky1.png               │     1923025 │
└───────────────────────────────┴─────────────┘
Saved 99% or 4.0 MB in 8 files (of 4.1 MB and 13 files in entire crate)
```