### PR TITLE
add skybox label to move_skybox system

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,6 +115,6 @@ impl Plugin for SkyboxPlugin {
         app.add_asset::<material::SkyMaterial>();
         app.add_startup_system(image::create_skybox.system());
         app.add_startup_system(create_pipeline.system());
-        app.add_system(move_skybox.system());
+        app.add_system(move_skybox.system().label("skybox"));
     }
 }


### PR DESCRIPTION
When attached to a camera which follows the player, I experienced the skybox itself jittering badly. Adding a "skybox" label allows this jitter to be resolved by running my camera movement system after the skybox system.